### PR TITLE
revert: remove ref_genes from merge_cnv_json config and schema

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -75,7 +75,6 @@ merge_cnv_json:
     - "cnv_sv/cnvkit_vcf/{sample}_T.pathology.annotate_cnv.germline.vcf.gz"
   annotations:
     - "ref_data/Myelom_expected_coverage_annotated_Oct2024_genes_only.bed"
-  ref_genes: "ref_data/refGene_hg38.txt"
 
 mosdepth:
   container: "docker://hydragenetics/mosdepth:0.3.6"

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -218,10 +218,7 @@ properties:
         items:
           type: string
         description: "Annotation files (BED) to annotate merge results."
-      ref_genes:
-        type: string
-        description: "Path to whitespace-separated text file with full gene coordinates used for CNV annotation."
-    required: ["germline_vcf", "unfiltered_cnv_vcfs", "filtered_cnv_vcfs", "annotations", "ref_genes"]
+    required: ["germline_vcf", "unfiltered_cnv_vcfs", "filtered_cnv_vcfs", "annotations"]
 
   mosdepth:
     type: object


### PR DESCRIPTION
ref_genes in config are required only by reports v0.11.0

### This PR:



Fixed: revert config schema and config file


### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
