### PR TITLE
fix: empty snv and tp53 tabs

### DIFF
--- a/.tests/unit/test_compile_xlsx_report.py
+++ b/.tests/unit/test_compile_xlsx_report.py
@@ -131,12 +131,26 @@ def test_parse_format(format_str, sample_str, expected):
         ),
         # Too few columns in VCF line
         ("chr1\t12345\t.\tA\tT", [], [], pytest.raises(ValueError)),
-        # GQ missing in the line
+        # GQ missing in the FORMAT string — parsed as empty string rather than error
+        # (e.g. DeepSomatic records lack AF; missing fields must not abort parsing)
         (
             "chr1\t12345\t.\tA\tT\t.\tPASS\tFAU=46;FCU=28;CSQ=gene1|impact1\tGT:DP\t0/1:25",
             ["Gene", "Impact"],
             ["GT", "DP", "GQ"],
-            pytest.raises(ValueError),
+            {
+                "CHROM": "chr1",
+                "POS": "12345",
+                "REF": "A",
+                "ALT": "T",
+                "QUAL": ".",
+                "FILTER": "PASS",
+                "CALLER": "",
+                "Gene": "gene1",
+                "Impact": "impact1",
+                "GT": "0/1",
+                "DP": "25",
+                "GQ": "",
+            },
         ),
         # You request too many VEP fields from the VCF file
         (

--- a/.tests/unit/test_fix_af.py
+++ b/.tests/unit/test_fix_af.py
@@ -1,0 +1,131 @@
+import io
+import logging
+import textwrap
+
+import pytest
+import pysam
+
+import sys
+from pathlib import Path
+
+TEST_DIR = Path(__file__).parent.resolve()
+SCRIPT_DIR = TEST_DIR / "../../workflow/scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from fix_af import modifyHeader, writeNewVcf  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VCF_HEADER_CLAIRS_TO = textwrap.dedent("""\
+    ##fileformat=VCFv4.2
+    ##FILTER=<ID=PASS,Description="All filters passed">
+    ##contig=<ID=chr1,length=248956422>
+    ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+    ##FORMAT=<ID=AF,Number=A,Type=Float,Description="Allele frequency">
+    ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Depth">
+    #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE
+    """)
+
+_VCF_HEADER_DEEPSOMATIC = textwrap.dedent("""\
+    ##fileformat=VCFv4.2
+    ##FILTER=<ID=PASS,Description="All filters passed">
+    ##contig=<ID=chr1,length=248956422>
+    ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+    ##FORMAT=<ID=VAF,Number=A,Type=Float,Description="Variant allele fraction">
+    ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Depth">
+    #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE
+    """)
+
+_VCF_HEADER_NO_AF_VAF = textwrap.dedent("""\
+    ##fileformat=VCFv4.2
+    ##FILTER=<ID=PASS,Description="All filters passed">
+    ##contig=<ID=chr1,length=248956422>
+    ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+    ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Depth">
+    #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE
+    """)
+
+
+def _write_vcf(tmp_path, name, header_str, data_lines):
+    """Write a plain-text VCF and bgzip+tabix it so pysam can read it."""
+    vcf_path = tmp_path / name
+    vcf_path.write_text(header_str + "".join(data_lines))
+    gz_path = tmp_path / (name + ".gz")
+    pysam.tabix_compress(str(vcf_path), str(gz_path), force=True)
+    pysam.tabix_index(str(gz_path), preset="vcf", force=True)
+    return str(gz_path)
+
+
+def _read_first_record(path):
+    vcf = pysam.VariantFile(path)
+    records = list(vcf.fetch())
+    assert records, "Expected at least one record"
+    return records[0]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestSnvConcatAfVafFallback:
+    """writeNewVcf with caller='snv_concat' AF→VAF fallback logic."""
+
+    def test_clairs_to_record_af_propagated_to_info(self, tmp_path):
+        """ClairS-TO style: FORMAT/AF present → INFO/AF set from FORMAT/AF."""
+        data = ["chr1\t100\t.\tA\tT\t.\tPASS\t.\tGT:AF:DP\t0/1:0.35:50\n"]
+        in_path = _write_vcf(tmp_path, "clairs_to.vcf", _VCF_HEADER_CLAIRS_TO, data)
+        out_path = str(tmp_path / "out_clairs.vcf.gz")
+
+        vcf = pysam.VariantFile(in_path)
+        header = modifyHeader("snv_concat", vcf.header)
+        writeNewVcf(out_path, header=header, vcf=vcf, caller="snv_concat")
+
+        rec = _read_first_record(out_path)
+        assert "AF" in rec.info, "INFO/AF should be set for a ClairS-TO record"
+        assert pytest.approx(rec.info["AF"][0]) == 0.35
+
+    def test_deepsomatic_record_vaf_fallback_to_info_af(self, tmp_path):
+        """DeepSomatic style: FORMAT/AF absent, FORMAT/VAF present → INFO/AF set from VAF."""
+        data = ["chr1\t200\t.\tG\tC\t.\tPASS\t.\tGT:VAF:DP\t0/1:0.42:60\n"]
+        in_path = _write_vcf(tmp_path, "deepsomatic.vcf", _VCF_HEADER_DEEPSOMATIC, data)
+        out_path = str(tmp_path / "out_deepsomatic.vcf.gz")
+
+        vcf = pysam.VariantFile(in_path)
+        header = modifyHeader("snv_concat", vcf.header)
+        writeNewVcf(out_path, header=header, vcf=vcf, caller="snv_concat")
+
+        rec = _read_first_record(out_path)
+        assert "AF" in rec.info, "INFO/AF should be populated via VAF fallback"
+        assert pytest.approx(rec.info["AF"][0]) == 0.42
+
+    def test_neither_af_nor_vaf_emits_warning_and_no_info_af(self, tmp_path, caplog):
+        """Record with neither FORMAT/AF nor FORMAT/VAF: INFO/AF absent, warning logged."""
+        data = ["chr1\t300\t.\tC\tT\t.\tPASS\t.\tGT:DP\t0/1:30\n"]
+        in_path = _write_vcf(tmp_path, "no_af.vcf", _VCF_HEADER_NO_AF_VAF, data)
+        out_path = str(tmp_path / "out_no_af.vcf.gz")
+
+        vcf = pysam.VariantFile(in_path)
+        header = modifyHeader("snv_concat", vcf.header)
+
+        with caplog.at_level(logging.WARNING, logger="root"):
+            writeNewVcf(out_path, header=header, vcf=vcf, caller="snv_concat")
+
+        assert any(
+            "neither FORMAT/AF nor FORMAT/VAF" in r.message for r in caplog.records
+        ), "Expected a warning about missing AF/VAF"
+
+        rec = _read_first_record(out_path)
+        assert "AF" not in rec.info, "INFO/AF must not be set when both AF and VAF are absent"
+
+    def test_no_exception_raised_for_deepsomatic_record(self, tmp_path):
+        """writeNewVcf must not raise for a DeepSomatic-style record."""
+        data = ["chr1\t400\t.\tT\tA\t.\tPASS\t.\tGT:VAF:DP\t1/1:0.95:80\n"]
+        in_path = _write_vcf(tmp_path, "deepsomatic2.vcf", _VCF_HEADER_DEEPSOMATIC, data)
+        out_path = str(tmp_path / "out_deepsomatic2.vcf.gz")
+
+        vcf = pysam.VariantFile(in_path)
+        header = modifyHeader("snv_concat", vcf.header)
+        writeNewVcf(out_path, header=header, vcf=vcf, caller="snv_concat")

--- a/workflow/scripts/compile_xlsx_report.py
+++ b/workflow/scripts/compile_xlsx_report.py
@@ -221,10 +221,10 @@ def parse_vcf_line(
     row.update(csq_dict)
 
     # populate row with values from FORMAT column
+    # Use empty string for fields absent from a particular record (e.g. AF is
+    # missing from DeepSomatic records which use VAF instead).
     for key in format_fields:
-        if key not in format_dict:
-            raise KeyError(f"Required FORMAT field '{key}' is missing in sample data.")
-        row[key] = format_dict[key]
+        row[key] = format_dict.get(key, "")
 
     return row
 

--- a/workflow/scripts/fix_af.py
+++ b/workflow/scripts/fix_af.py
@@ -100,6 +100,12 @@ def writeNewVcf(
                 af = row.samples[0].get("VAF")
             if af is not None:
                 row.info["AF"] = af
+            else:
+                logging.warning(
+                    "Record at %s:%s has neither FORMAT/AF nor FORMAT/VAF; INFO/AF will not be set.",
+                    row.chrom,
+                    row.pos,
+                )
         elif caller == "gatk_select_variants_final":
             row.info["AF"] = row.samples[0].get("AF")
         elif caller == "varscan":

--- a/workflow/scripts/fix_af.py
+++ b/workflow/scripts/fix_af.py
@@ -93,7 +93,13 @@ def writeNewVcf(
             row.info["AF"] = row.samples[0].get("VAF")
             row.samples[0]["AF"] = row.samples[0].get("VAF")
         elif caller in ("clairs_to", "snv_concat"):
-            row.info["AF"] = row.samples[0].get("AF")
+            # ClairS-TO reports FORMAT/AF; DeepSomatic reports FORMAT/VAF.
+            # Try AF first, fall back to VAF so both caller types are handled.
+            af = row.samples[0].get("AF")
+            if af is None:
+                af = row.samples[0].get("VAF")
+            if af is not None:
+                row.info["AF"] = af
         elif caller == "gatk_select_variants_final":
             row.info["AF"] = row.samples[0].get("AF")
         elif caller == "varscan":


### PR DESCRIPTION
### This PR:

Fixed: empty SNV tab because of incorrect parsing of DeepSomatic VAF field.


### Review and tests: 
- [x] Tests pass
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Code review
- [x] `CHANGELOG.md` is updated
- [x] New code is executed and covered by tests, and test approve


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Graceful handling of incomplete VCF records: missing FORMAT keys now yield empty values instead of errors.
  * Added fallback for allele-frequency derivation (use VAF when AF is absent) and emit warnings when neither is present.

* **Tests**
  * Updated tests to reflect tolerant parsing for missing FORMAT fields.
  * Added unit tests covering AF/VAF fallback behavior and warning/logging for missing allele-frequency fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->