### PR TITLE
fix: derive PBSV VAF from AD and format all SV VAF to 2 decimal places

### DIFF
--- a/.tests/unit/test_compile_xlsx_report.py
+++ b/.tests/unit/test_compile_xlsx_report.py
@@ -455,3 +455,6 @@ def test_process_sv_vcf_pbsv_vaf_derived_from_ad(tmp_path):
     assert vaf_str == "0.25", (
         f"Expected VAF = alt_depth/total_depth formatted to 2 d.p. = '0.25', got {vaf_str!r}"
     )
+    assert df["SUPPORT"].iloc[0] == "10", (
+        f"Expected SUPPORT = AD[1] = 10 for a PBSV record, got {df['SUPPORT'].iloc[0]!r}"
+    )

--- a/.tests/unit/test_compile_xlsx_report.py
+++ b/.tests/unit/test_compile_xlsx_report.py
@@ -415,5 +415,43 @@ def test_process_sv_vcf_svlen_tuple_parsed_as_number(tmp_path):
 
     # SUPPORT and VAF should also be unwrapped
     assert df["SUPPORT"].iloc[0] == "10", f"SUPPORT was {df['SUPPORT'].iloc[0]!r}, expected '10'"
-    assert df["VAF"].iloc[0] == "0.5", f"VAF was {df['VAF'].iloc[0]!r}, expected '0.5'"
+    assert df["VAF"].iloc[0] == "0.50", f"VAF was {df['VAF'].iloc[0]!r}, expected '0.50'"
     assert df["END"].iloc[0] == "6000", f"END was {df['END'].iloc[0]!r}, expected '6000'"
+
+
+# --- Regression test: PBSV VAF derived from AD ---
+
+_SV_VCF_PBSV_NO_VAF = """\
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##contig=<ID=chr14,length=107043718>
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="SV type">
+##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="SV length">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position">
+##INFO=<ID=svdb_origin,Number=1,Type=String,Description="Caller origin">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for ref and alt">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Total depth">
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE
+chr14\t5000\tpbsv.BND.1\tN\t<BND>\t.\tPASS\tSVTYPE=BND;SVLEN=10000;END=15000;svdb_origin=pbsv\tGT:AD:DP\t0/1:30,10:40
+"""
+
+
+def test_process_sv_vcf_pbsv_vaf_derived_from_ad(tmp_path):
+    """PBSV records carry FORMAT/AD (ref, alt) but no FORMAT/VAF.
+    process_sv_vcf must derive VAF from AD so the SV and Translocations tabs
+    are not silently left with empty VAF when only Severus+PBSV are merged."""
+    vcf_path = tmp_path / "sv_pbsv_no_vaf.vcf"
+    vcf_path.write_text(_SV_VCF_PBSV_NO_VAF)
+    gz_path = str(tmp_path / "sv_pbsv_no_vaf.vcf.gz")
+    pysam.tabix_compress(str(vcf_path), gz_path, force=True)
+    pysam.tabix_index(gz_path, preset="vcf", force=True)
+
+    df = process_sv_vcf(gz_path)
+    assert len(df) == 1, "Expected one record"
+
+    vaf_str = df["VAF"].iloc[0]
+    assert vaf_str != "", "VAF must not be empty for a PBSV record with AD"
+    assert vaf_str == "0.25", (
+        f"Expected VAF = alt_depth/total_depth formatted to 2 d.p. = '0.25', got {vaf_str!r}"
+    )

--- a/workflow/scripts/compile_xlsx_report.py
+++ b/workflow/scripts/compile_xlsx_report.py
@@ -395,9 +395,7 @@ def process_sv_vcf(vcf_path: str) -> pd.DataFrame:
             # Use 'in' instead of .get() — pysam raises ValueError for keys not
             # in the header, while 'in' safely returns False.
             strand = (
-                record.info["STRAND"] if "STRAND" in record.info else
-                record.info["STRANDS"] if "STRANDS" in record.info else
-                ""
+                record.info["STRAND"] if "STRAND" in record.info else record.info["STRANDS"] if "STRANDS" in record.info else ""
             )
 
             # ── VAF: INFO first (Sniffles2), FORMAT fallback (Severus) ────────────
@@ -422,7 +420,9 @@ def process_sv_vcf(vcf_path: str) -> pd.DataFrame:
                 "FILTER": ";".join(record.filter.keys()) or ".",
                 "CALLER": caller,
                 "COVERAGE": coverage,
-                "SUPPORT": str(unwrap_info(record.info["SUPPORT"])) if "SUPPORT" in record.info else (str(dv) if dv is not None else ""),
+                "SUPPORT": (
+                    str(unwrap_info(record.info["SUPPORT"])) if "SUPPORT" in record.info else (str(dv) if dv is not None else "")
+                ),
                 "STRAND": strand,
                 "VAF": f"{_vaf:.2f}" if _vaf is not None else "",
                 "GENOTYPE": gt,

--- a/workflow/scripts/compile_xlsx_report.py
+++ b/workflow/scripts/compile_xlsx_report.py
@@ -410,6 +410,8 @@ def process_sv_vcf(vcf_path: str) -> pd.DataFrame:
                 if total > 0:
                     vaf = round(dv / total, 4)
 
+            _vaf = unwrap_info(vaf) if vaf is not None else None
+
             row = {
                 "CHROM": record.chrom,
                 "POS": str(record.pos),
@@ -422,7 +424,7 @@ def process_sv_vcf(vcf_path: str) -> pd.DataFrame:
                 "COVERAGE": coverage,
                 "SUPPORT": str(unwrap_info(record.info["SUPPORT"])) if "SUPPORT" in record.info else (str(dv) if dv is not None else ""),
                 "STRAND": strand,
-                "VAF": f"{unwrap_info(vaf):.2f}" if vaf is not None else "",
+                "VAF": f"{_vaf:.2f}" if _vaf is not None else "",
                 "GENOTYPE": gt,
                 "GENOME QUALITY": gq,
                 "DEPTH REF": str(dr) if dr is not None else "",

--- a/workflow/scripts/compile_xlsx_report.py
+++ b/workflow/scripts/compile_xlsx_report.py
@@ -420,7 +420,7 @@ def process_sv_vcf(vcf_path: str) -> pd.DataFrame:
                 "FILTER": ";".join(record.filter.keys()) or ".",
                 "CALLER": caller,
                 "COVERAGE": coverage,
-                "SUPPORT": str(unwrap_info(record.info["SUPPORT"])) if "SUPPORT" in record.info else "",
+                "SUPPORT": str(unwrap_info(record.info["SUPPORT"])) if "SUPPORT" in record.info else (str(dv) if dv is not None else ""),
                 "STRAND": strand,
                 "VAF": f"{unwrap_info(vaf):.2f}" if vaf is not None else "",
                 "GENOTYPE": gt,

--- a/workflow/scripts/compile_xlsx_report.py
+++ b/workflow/scripts/compile_xlsx_report.py
@@ -392,12 +392,23 @@ def process_sv_vcf(vcf_path: str) -> pd.DataFrame:
                 coverage = ""
 
             # ── STRAND / STRANDS ─────────────────────────────────────────────────
-            strand = record.info.get("STRAND") or record.info.get("STRANDS") or ""
+            # Use 'in' instead of .get() — pysam raises ValueError for keys not
+            # in the header, while 'in' safely returns False.
+            strand = (
+                record.info["STRAND"] if "STRAND" in record.info else
+                record.info["STRANDS"] if "STRANDS" in record.info else
+                ""
+            )
 
             # ── VAF: INFO first (Sniffles2), FORMAT fallback (Severus) ────────────
             vaf = record.info["VAF"] if "VAF" in record.info else None
             if vaf is None and samp is not None:
                 vaf = samp.get("VAF")
+            # PBSV carries AD (ref, alt) instead of VAF; derive VAF from depth counts
+            if vaf is None and dr is not None and dv is not None:
+                total = (dr or 0) + (dv or 0)
+                if total > 0:
+                    vaf = round(dv / total, 4)
 
             row = {
                 "CHROM": record.chrom,
@@ -411,7 +422,7 @@ def process_sv_vcf(vcf_path: str) -> pd.DataFrame:
                 "COVERAGE": coverage,
                 "SUPPORT": str(unwrap_info(record.info["SUPPORT"])) if "SUPPORT" in record.info else "",
                 "STRAND": strand,
-                "VAF": str(unwrap_info(vaf)) if vaf is not None else "",
+                "VAF": f"{unwrap_info(vaf):.2f}" if vaf is not None else "",
                 "GENOTYPE": gt,
                 "GENOME QUALITY": gq,
                 "DEPTH REF": str(dr) if dr is not None else "",


### PR DESCRIPTION
before, VAF values were absent if caller was pbsv or severus AND pbsv

### This PR:

Added: VAF rounded to two dec. places
Fixed: absent VAF if callers are pbsv or severus AND pbsv

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when processing VCF files with missing strand information
  * Enhanced VAF (variant allele frequency) calculation to derive values from sequencing depth when unavailable in source data
  * SUPPORT field now provides meaningful values instead of remaining empty

* **Tests**
  * Added regression test for alternate VCF format scenarios with missing VAF fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->