### PR TITLE
chore: use new reports release v2.0.0 as default

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -16,7 +16,7 @@ module_versions:
   cnv_sv: "develop"
   filtering: "v1.1.0"
   prealignment: "v1.4.0"
-  reports: "e3b0bbe40fba933961bf2b963c9cd339db2afbb5" # update_table branch tip: fixes ploidy param bug, adds table_filter_config
+  reports: "v2.0.0"
   snv_indels: "v2.0.0"
   qc: "v0.7.0"
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -37,7 +37,7 @@ The interactive CNV HTML report (`hydra-genetics/reports` module, `cnv_html_repo
 * `config/cytoBand.hg38.txt` — UCSC cytoband definitions for hg38, referenced by `merge_cnv_json.cytobands` in `config.yaml`. Displays cytobands in the report's chromosome plot; requires `cnv_html_report.cytobands: true` to be enabled as well.
 * `config/filters/table_filter.yaml` — defines named CNV classification/filter groups (e.g. amplification, deletion, LOH) used to populate the results table's **Type** column and its "filtered" toggle, referenced by `merge_cnv_json.table_filter_config`. Each group is a tree of `any_of`/`all_of`/`not` conditions over fields such as `adjusted_cn`, `baf`, `length`, and `caller`; thresholds are clinical choices and should be tuned rather than used as shipped.
 
-See the full syntax reference in the `reports` module's own docs: [CNV report configuration](https://github.com/hydra-genetics/reports/blob/e3b0bbe40fba933961bf2b963c9cd339db2afbb5/docs/cnv_report.md) (pinned to the same commit as `module_versions.reports` in `config.yaml`).
+See the full syntax reference in the `reports` module's own docs: [CNV report configuration](https://hydra-genetics-reports.readthedocs.io/en/v2.0.0/cnv_report/) (pinned to the same version as `module_versions.reports` in `config.yaml`).
 
 ```yaml
 # ex, default resources


### PR DESCRIPTION
### This PR:

Added: use reports v2.0.0 as default

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the reports module to version 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->